### PR TITLE
Updated A-Frame release in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ by
 [@AndraConnect](https://twitter.com/AndraConnect).
 
 ```html
-<script src="https://aframe.io/releases/0.5.0/aframe.min.js"></script>
+<script src="https://aframe.io/releases/0.6.0/aframe.min.js"></script>
 <script src="https://jeromeetienne.github.io/AR.js/aframe/build/aframe-ar.js"></script>
 <body style='margin : 0px; overflow: hidden;'>
 	<a-scene embedded artoolkit='sourceType: webcam;'>


### PR DESCRIPTION
Tried out the AR in 10 lines code, but was getting errors in both Firefox and Chrome. Updating to A-Frame release 0.6.0 or 0.6.1 fixes the errors and  example then works as intended.