### PR TITLE
Automatic back camera selection for exotic browsers (Wechat)

### DIFF
--- a/three.js/src/threex/threex-artoolkitsource.js
+++ b/three.js/src/threex/threex-artoolkitsource.js
@@ -1,7 +1,7 @@
 var ARjs = ARjs || {}
 var THREEx = THREEx || {}
 
-ARjs.Source = THREEx.ArToolkitSource = function(parameters){	
+ARjs.Source = THREEx.ArToolkitSource = function(parameters){
 	var _this = this
 
 	this.ready = false
@@ -10,14 +10,14 @@ ARjs.Source = THREEx.ArToolkitSource = function(parameters){
 	// handle default parameters
 	this.parameters = {
 		// type of source - ['webcam', 'image', 'video']
-		sourceType : 'webcam',
+    sourceType : 'webcam',
 		// url of the source - valid if sourceType = image|video
 		sourceUrl : null,
-		
+
 		// resolution of at which we initialize in the source image
 		sourceWidth: 640,
 		sourceHeight: 480,
-		// resolution displayed for the source 
+		// resolution displayed for the source
 		displayWidth: 640,
 		displayHeight: 480,
 	}
@@ -44,7 +44,7 @@ ARjs.Source = THREEx.ArToolkitSource = function(parameters){
 
 			_this.parameters[ key ] = newValue
 		}
-	}	
+	}
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -54,12 +54,12 @@ ARjs.Source.prototype.init = function(onReady, onError){
 	var _this = this
 
         if( this.parameters.sourceType === 'image' ){
-                var domElement = this._initSourceImage(onSourceReady, onError)                        
+                var domElement = this._initSourceImage(onSourceReady, onError)
         }else if( this.parameters.sourceType === 'video' ){
-                var domElement = this._initSourceVideo(onSourceReady, onError)                        
+                var domElement = this._initSourceVideo(onSourceReady, onError)
         }else if( this.parameters.sourceType === 'webcam' ){
-                // var domElement = this._initSourceWebcamOld(onSourceReady)                        
-                var domElement = this._initSourceWebcam(onSourceReady, onError)                        
+                // var domElement = this._initSourceWebcamOld(onSourceReady)
+                var domElement = this._initSourceWebcam(onSourceReady, onError)
         }else{
                 console.assert(false)
         }
@@ -79,7 +79,7 @@ ARjs.Source.prototype.init = function(onReady, onError){
 
 		onReady && onReady()
         }
-} 
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //          init image source
@@ -103,7 +103,7 @@ ARjs.Source.prototype._initSourceImage = function(onReady) {
 		clearInterval(interval)
 	}, 1000/50);
 
-	return domElement                
+	return domElement
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -134,7 +134,7 @@ ARjs.Source.prototype._initSourceVideo = function(onReady) {
 	domElement.height = this.parameters.sourceHeight
 	domElement.style.width = this.parameters.displayWidth+'px'
 	domElement.style.height = this.parameters.displayHeight+'px'
-	
+
 	// wait until the video stream is ready
 	var interval = setInterval(function() {
 		if (!domElement.videoWidth)	return;
@@ -152,7 +152,7 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
 	var _this = this
 
 	// init default value
-	onError = onError || function(error){	
+	onError = onError || function(error){
 		alert('Webcam Error\nName: '+error.name + '\nMessage: '+error.message)
 	}
 
@@ -163,9 +163,8 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
 	domElement.style.width = this.parameters.displayWidth+'px'
 	domElement.style.height = this.parameters.displayHeight+'px'
 
-	// check API is available
-	if (navigator.mediaDevices === undefined 
-			|| navigator.mediaDevices.enumerateDevices === undefined 
+	if (navigator.mediaDevices === undefined
+			|| navigator.mediaDevices.enumerateDevices === undefined
 			|| navigator.mediaDevices.getUserMedia === undefined  ){
 		if( navigator.mediaDevices === undefined )				var fctName = 'navigator.mediaDevices'
 		else if( navigator.mediaDevices.enumerateDevices === undefined )	var fctName = 'navigator.mediaDevices.enumerateDevices'
@@ -180,10 +179,20 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
 
 	// get available devices
 	navigator.mediaDevices.enumerateDevices().then(function(devices) {
-                var userMediaConstraints = {
+
+		var backVideoInputId = false
+		for (var i = devices.length - 1; i >= 0; i--) {
+			if(
+        devices[i].kind === 'videoinput' &&
+        devices[i].label.indexOf("back") !== -1
+      ) backVideoInputId = devices[i].deviceId;
+		}
+
+    var userMediaConstraints = {
 			audio: false,
 			video: {
 				facingMode: 'environment',
+				deviceId: backVideoInputId,
 				width: {
 					ideal: _this.parameters.sourceWidth,
 					// min: 1024,
@@ -194,8 +203,8 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
 					// min: 776,
 					// max: 1080
 				}
-		  	}
-                }
+	  	}
+    }
 		// get a device which satisfy the constraints
 		navigator.mediaDevices.getUserMedia(userMediaConstraints).then(function success(stream) {
 			// set the .src of the domElement
@@ -245,7 +254,7 @@ ARjs.Source.prototype.hasMobileTorch = function(){
 	if( videoTrack.getCapabilities === undefined )	return false
 
 	var capabilities = videoTrack.getCapabilities()
-	
+
 	return capabilities.torch ? true : false
 }
 
@@ -256,7 +265,7 @@ ARjs.Source.prototype.hasMobileTorch = function(){
 ARjs.Source.prototype.toggleMobileTorch = function(){
 	// sanity check
 	console.assert(this.hasMobileTorch() === true)
-		
+
 	var stream = arToolkitSource.domElement.srcObject
 	if( stream instanceof MediaStream === false ){
 		alert('enabling mobile torch is available only on webcam')
@@ -269,7 +278,7 @@ ARjs.Source.prototype.toggleMobileTorch = function(){
 
 	var videoTrack = stream.getVideoTracks()[0];
 	var capabilities = videoTrack.getCapabilities()
-	
+
 	if( !capabilities.torch ){
 		alert('no mobile torch is available on your camera')
 		return
@@ -304,7 +313,7 @@ ARjs.Source.prototype.onResizeElement = function(mirrorDomElements){
 	}else{
 		console.assert(false)
 	}
-	
+
 	// compute sourceAspect
 	var sourceAspect = sourceWidth / sourceHeight
 	// compute screenAspect
@@ -316,7 +325,7 @@ ARjs.Source.prototype.onResizeElement = function(mirrorDomElements){
 		var newWidth = sourceAspect * screenHeight
 		this.domElement.style.width = newWidth+'px'
 		this.domElement.style.marginLeft = -(newWidth-screenWidth)/2+'px'
-		
+
 		// init style.height/.marginTop to normal value
 		this.domElement.style.height = screenHeight+'px'
 		this.domElement.style.marginTop = '0px'
@@ -325,13 +334,13 @@ ARjs.Source.prototype.onResizeElement = function(mirrorDomElements){
 		var newHeight = 1 / (sourceAspect / screenWidth)
 		this.domElement.style.height = newHeight+'px'
 		this.domElement.style.marginTop = -(newHeight-screenHeight)/2+'px'
-		
+
 		// init style.width/.marginLeft to normal value
 		this.domElement.style.width = screenWidth+'px'
 		this.domElement.style.marginLeft = '0px'
 	}
-	
-	
+
+
 	if( arguments.length !== 0 ){
 		debugger
 		console.warn('use bad signature for arToolkitSource.copyElementSizeTo')
@@ -339,7 +348,7 @@ ARjs.Source.prototype.onResizeElement = function(mirrorDomElements){
 	// honor default parameters
 	// if( mirrorDomElements !== undefined )	console.warn('still use the old resize. fix it')
 	if( mirrorDomElements === undefined )	mirrorDomElements = []
-	if( mirrorDomElements instanceof Array === false )	mirrorDomElements = [mirrorDomElements]	
+	if( mirrorDomElements instanceof Array === false )	mirrorDomElements = [mirrorDomElements]
 
 	// Mirror _this.domElement.style to mirrorDomElements
 	mirrorDomElements.forEach(function(domElement){
@@ -349,7 +358,7 @@ ARjs.Source.prototype.onResizeElement = function(mirrorDomElements){
 
 ARjs.Source.prototype.copyElementSizeTo = function(otherElement){
 	otherElement.style.width = this.domElement.style.width
-	otherElement.style.height = this.domElement.style.height	
+	otherElement.style.height = this.domElement.style.height
 	otherElement.style.marginLeft = this.domElement.style.marginLeft
 	otherElement.style.marginTop = this.domElement.style.marginTop
 }
@@ -374,28 +383,28 @@ ARjs.Source.prototype.onResize	= function(arToolkitContext, renderer, camera){
 	}
 
 	var trackingBackend = arToolkitContext.parameters.trackingBackend
-	
+
 
 	// RESIZE DOMELEMENT
 	if( trackingBackend === 'artoolkit' ){
 
 		this.onResizeElement()
-		
+
 		var isAframe = renderer.domElement.dataset.aframeCanvas ? true : false
 		if( isAframe === false ){
-			this.copyElementSizeTo(renderer.domElement)	
+			this.copyElementSizeTo(renderer.domElement)
 		}else{
-			
+
 		}
 
 		if( arToolkitContext.arController !== null ){
-			this.copyElementSizeTo(arToolkitContext.arController.canvas)	
+			this.copyElementSizeTo(arToolkitContext.arController.canvas)
 		}
 	}else if( trackingBackend === 'aruco' ){
 		this.onResizeElement()
-		this.copyElementSizeTo(renderer.domElement)	
+		this.copyElementSizeTo(renderer.domElement)
 
-		this.copyElementSizeTo(arToolkitContext.arucoContext.canvas)	
+		this.copyElementSizeTo(arToolkitContext.arucoContext.canvas)
 	}else if( trackingBackend === 'tango' ){
 		renderer.setSize( window.innerWidth, window.innerHeight )
 	}else console.assert(false, 'unhandled trackingBackend '+trackingBackend)
@@ -404,14 +413,14 @@ ARjs.Source.prototype.onResize	= function(arToolkitContext, renderer, camera){
 	// UPDATE CAMERA
 	if( trackingBackend === 'artoolkit' ){
 		if( arToolkitContext.arController !== null ){
-			camera.projectionMatrix.copy( arToolkitContext.getProjectionMatrix() );			
+			camera.projectionMatrix.copy( arToolkitContext.getProjectionMatrix() );
 		}
-	}else if( trackingBackend === 'aruco' ){	
+	}else if( trackingBackend === 'aruco' ){
 		camera.aspect = renderer.domElement.width / renderer.domElement.height;
-		camera.updateProjectionMatrix();			
+		camera.updateProjectionMatrix();
 	}else if( trackingBackend === 'tango' ){
 		var vrDisplay = arToolkitContext._tangoContext.vrDisplay
 		// make camera fit vrDisplay
 		if( vrDisplay && vrDisplay.displayName === "Tango VR Device" ) THREE.WebAR.resizeVRSeeThroughCamera(vrDisplay, camera)
-	}else console.assert(false, 'unhandled trackingBackend '+trackingBackend)	
+	}else console.assert(false, 'unhandled trackingBackend '+trackingBackend)
 }


### PR DESCRIPTION
A suggestion of approach to solve a problem appearing of Wechat Browser in android
Another way suggested on the issue feed #178 

---

I suggest to not ask which camera to use, as we suppose that AR is usually using back camera for obvious UX reasons (hard to place a marker on the front camera).

If we asked the question, we will need a mechanism to keep the answer, to not get triggered everytime the experience get loaded, thus recording it using a cookie or something, which is a bit heavy UX-wise I feel, especially knowing that we will either need to use an uncustomized native prompt() or a customized popup system, in both cases, its adding some UI on the system, which is not optimal.

Another solution would be to expose which webcam to select inside the parameters of ArToolkitSource something like :

```
this.parameters = {
		// type of source - ['webcam', 'image', 'video']
               sourceType : 'webcam',
               // ['back', 'front']
               webcamDirection : 'back' ,
		...
	}
```

So I choose not to ask, working fine in my case, so what I do is :

- detect if there are several video devices
- if so, detect if one has the "back" word in its label, if yes take that one as deviceId
- else, do not precise the deviceId inside userMediaConstraints to fallback on the default one

Line 182 in three.js/src/threex/threex-artoolkitsource.js
```

navigator.mediaDevices.enumerateDevices().then(function(devices) {

  var backVideoInputId = false
  for (var i = devices.length - 1; i >= 0; i--) {
    if(
         devices[i].kind === 'videoinput' &&
         devices[i].label.indexOf("back") !== -1
    ) { 
      backVideoInputId = devices[i].deviceId;
    }
  }

  var userMediaConstraints = {
    audio: false,
    video: {
        facingMode: 'environment',
        deviceId: backVideoInputId,
        width: {
            ....
        }
    }

```