### PR TITLE
Remove heavy examples and demo data from npm package distribution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+test
+aframe/examples
+babylon.js/examples
+three.js/examples
+webvr-polyfill/examples
+data/NFT
+data/images
+data/logo
+data/videos


### PR DESCRIPTION
Create a .npmignore file avoid to pack hevy examples in the npm package distribution.

Without this file, npm package is 250 Mb, 
With this file, it's only 3.5 Mb