### PR TITLE
Added deviceId parameter to the scene - it will set what camera to us…

### DIFF
--- a/aframe/build/aframe-ar.js
+++ b/aframe/build/aframe-ar.js
@@ -5797,7 +5797,10 @@ ARjs.Source = THREEx.ArToolkitSource = function(parameters){
 		sourceType : 'webcam',
 		// url of the source - valid if sourceType = image|video
 		sourceUrl : null,
-		
+
+		// Device id of the camera to use (optional)
+		deviceId : null,
+
 		// resolution of at which we initialize in the source image
 		sourceWidth: 640,
 		sourceHeight: 480,
@@ -5979,7 +5982,14 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
 					// max: 1080
 				}
 		  	}
-                }
+		}
+
+		if (null !== _this.parameters.deviceId) {
+			userMediaConstraints.video.deviceId = {
+				exact: _this.parameters.deviceId
+			};
+		}
+
 		// get a device which satisfy the constraints
 		navigator.mediaDevices.getUserMedia(userMediaConstraints).then(function success(stream) {
 			// set the .src of the domElement
@@ -8579,6 +8589,10 @@ AFRAME.registerSystem('arjs', {
 			type: 'number',
 			default: -1
 		},
+		deviceId : {
+			type: 'string',
+			default: ''
+		},
 		displayWidth : {
 			type: 'number',
 			default: -1
@@ -8635,6 +8649,7 @@ AFRAME.registerSystem('arjs', {
 		if( this.data.sourceUrl !== '' )		arProfile.sourceParameters.sourceUrl = this.data.sourceUrl
 		if( this.data.sourceWidth !== -1 )		arProfile.sourceParameters.sourceWidth = this.data.sourceWidth
 		if( this.data.sourceHeight !== -1 )		arProfile.sourceParameters.sourceHeight = this.data.sourceHeight
+		if( this.data.deviceId !== '' )		arProfile.sourceParameters.deviceId = this.data.deviceId
 		if( this.data.displayWidth !== -1 )		arProfile.sourceParameters.displayWidth = this.data.displayWidth
 		if( this.data.displayHeight !== -1 )		arProfile.sourceParameters.displayHeight = this.data.displayHeight
 

--- a/aframe/src/system-arjs.js
+++ b/aframe/src/system-arjs.js
@@ -63,6 +63,10 @@ AFRAME.registerSystem('arjs', {
 			type: 'number',
 			default: -1
 		},
+		deviceId : {
+			type: 'string',
+			default: ''
+		},
 		displayWidth : {
 			type: 'number',
 			default: -1
@@ -119,6 +123,7 @@ AFRAME.registerSystem('arjs', {
 		if( this.data.sourceUrl !== '' )		arProfile.sourceParameters.sourceUrl = this.data.sourceUrl
 		if( this.data.sourceWidth !== -1 )		arProfile.sourceParameters.sourceWidth = this.data.sourceWidth
 		if( this.data.sourceHeight !== -1 )		arProfile.sourceParameters.sourceHeight = this.data.sourceHeight
+		if( this.data.deviceId !== '' )		arProfile.sourceParameters.deviceId = this.data.deviceId
 		if( this.data.displayWidth !== -1 )		arProfile.sourceParameters.displayWidth = this.data.displayWidth
 		if( this.data.displayHeight !== -1 )		arProfile.sourceParameters.displayHeight = this.data.displayHeight
 

--- a/three.js/build/ar.js
+++ b/three.js/build/ar.js
@@ -5797,7 +5797,10 @@ ARjs.Source = THREEx.ArToolkitSource = function(parameters){
 		sourceType : 'webcam',
 		// url of the source - valid if sourceType = image|video
 		sourceUrl : null,
-		
+
+		// Device id of the camera to use (optional)
+		deviceId : null,
+
 		// resolution of at which we initialize in the source image
 		sourceWidth: 640,
 		sourceHeight: 480,
@@ -5979,7 +5982,14 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
 					// max: 1080
 				}
 		  	}
-                }
+		}
+
+		if (null !== _this.parameters.deviceId) {
+			userMediaConstraints.video.deviceId = {
+				exact: _this.parameters.deviceId
+			};
+		}
+
 		// get a device which satisfy the constraints
 		navigator.mediaDevices.getUserMedia(userMediaConstraints).then(function success(stream) {
 			// set the .src of the domElement

--- a/three.js/contribs/portableAR.js/build/portable-ar.js
+++ b/three.js/contribs/portableAR.js/build/portable-ar.js
@@ -49907,7 +49907,10 @@ ARjs.Source = THREEx.ArToolkitSource = function(parameters){
 		sourceType : 'webcam',
 		// url of the source - valid if sourceType = image|video
 		sourceUrl : null,
-		
+
+		// Device id of the camera to use (optional)
+		deviceId : null,
+
 		// resolution of at which we initialize in the source image
 		sourceWidth: 640,
 		sourceHeight: 480,
@@ -50089,7 +50092,14 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
 					// max: 1080
 				}
 		  	}
-                }
+		}
+
+		if (null !== _this.parameters.deviceId) {
+			userMediaConstraints.video.deviceId = {
+				exact: _this.parameters.deviceId
+			};
+		}
+
 		// get a device which satisfy the constraints
 		navigator.mediaDevices.getUserMedia(userMediaConstraints).then(function success(stream) {
 			// set the .src of the domElement

--- a/three.js/src/threex/threex-artoolkitsource.js
+++ b/three.js/src/threex/threex-artoolkitsource.js
@@ -13,7 +13,10 @@ ARjs.Source = THREEx.ArToolkitSource = function(parameters){
 		sourceType : 'webcam',
 		// url of the source - valid if sourceType = image|video
 		sourceUrl : null,
-		
+
+		// Device id of the camera to use (optional)
+		deviceId : null,
+
 		// resolution of at which we initialize in the source image
 		sourceWidth: 640,
 		sourceHeight: 480,
@@ -195,7 +198,14 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
 					// max: 1080
 				}
 		  	}
-                }
+		}
+
+		if (null !== _this.parameters.deviceId) {
+			userMediaConstraints.video.deviceId = {
+				exact: _this.parameters.deviceId
+			};
+		}
+
 		// get a device which satisfy the constraints
 		navigator.mediaDevices.getUserMedia(userMediaConstraints).then(function success(stream) {
 			// set the .src of the domElement


### PR DESCRIPTION
…e based on its deviceId

<!-- Please don't delete this template or we'll close your issue -->
<!-- All PRs should be done versus 'dev' branch -->
**What kind of change does this PR introduce?**
<!-- Can be a new feature, a bugfix, or refactoring, etc -->
This is a new feature - allows to define the deviceId to use for the camera.

** Can it be referenced to an Issue? If so what is the issue # ?**
Might be useful for this issue : #178 

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->

You can use this feature by defining the deviceid as a parameter in the scene, like this :
 ` <a-scene embedded arjs="detectionMode: mono_and_matrix; matrixCodeType: 3x3; sourceType: webcam; trackingMethod: best; debugUIEnabled: false; deviceId: 10d9f755ccab290ef5dbd4a1bb27cca11e61677ab0b4356f302e098ef6144813;" antialias="true">`

In order to get the deviceId, you can use getUserMedia.

**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->
**Does this PR introduce a breaking change?**
It doesn't. The previous behaviour to select what camera to pick up is the default one. The deviceId parameter is optional.

**Other information**
