### PR TITLE
Marker generator: Keep the file name

### DIFF
--- a/three.js/examples/marker-training/examples/generator.html
+++ b/three.js/examples/marker-training/examples/generator.html
@@ -165,6 +165,7 @@
 <script>
 	var innerImageURL = null
 	var fullMarkerURL = null
+	var imageName = null
 
 	innerImageURL = 'inner-images/inner-arjs.png'
 	updateFullMarkerImage()
@@ -176,7 +177,7 @@
 		}
 		console.assert(innerImageURL)
 		THREEx.ArPatternFile.encodeImageURL(innerImageURL, function onComplete(patternFileString){
-			THREEx.ArPatternFile.triggerDownload(patternFileString)
+			THREEx.ArPatternFile.triggerDownload(patternFileString, "pattern-" + (imageName || "marker") + ".patt")
 		})
 	})
 
@@ -191,7 +192,7 @@
 		// tech from https://stackoverflow.com/questions/3665115/create-a-file-in-memory-for-user-to-download-not-through-server
 		var domElement = window.document.createElement('a');
 		domElement.href = fullMarkerURL;
-		domElement.download = 'marker.png';
+		domElement.download = "pattern-" + (imageName || 'marker') + '.png';
 		document.body.appendChild(domElement)
 		domElement.click();
 		document.body.removeChild(domElement)
@@ -212,6 +213,10 @@
 
 	document.querySelector('#fileinput').addEventListener('change', function(){
 		var file = this.files[0];
+		imageName = file.name
+		// remove file extension
+		imageName = imageName.substring(0, imageName.lastIndexOf('.')) || imageName
+		
 		// debugger
 
 		var reader = new FileReader();

--- a/three.js/examples/marker-training/threex-arpatternfile.js
+++ b/three.js/examples/marker-training/threex-arpatternfile.js
@@ -70,11 +70,11 @@ THREEx.ArPatternFile.encodeImage = function(image){
 //		trigger download
 //////////////////////////////////////////////////////////////////////////////
 
-THREEx.ArPatternFile.triggerDownload =  function(patternFileString){
+THREEx.ArPatternFile.triggerDownload =  function(patternFileString, fileName = 'pattern-marker.patt'){
 	// tech from https://stackoverflow.com/questions/3665115/create-a-file-in-memory-for-user-to-download-not-through-server
 	var domElement = window.document.createElement('a');
 	domElement.href = window.URL.createObjectURL(new Blob([patternFileString], {type: 'text/plain'}));
-	domElement.download = 'pattern-marker.patt';
+	domElement.download = fileName;
 	document.body.appendChild(domElement)
 	domElement.click();
 	document.body.removeChild(domElement)


### PR DESCRIPTION
<!-- Please don't delete this template or we'll close your issue -->
<!-- All PRs should be done versus 'dev' branch -->
**What kind of change does this PR introduce?**
New feature: The marker generator keeps the file name of the file uploaded, instead of naming all markers "pattern-marker.patt" and all images "marker.png". 

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->

You need an image, say `alice.png`.
Open `three.js/examples/marker-training/examples/generator.html` in your browser.
Click the "UPLOAD" button and select the file.
Then click the "DOWNLOAD MARKER" button. The downloaded file is called `pattern-alice.patt`.
Finally, click the "DOWNLOAD IMAGE" button. The downloaded file is called `pattern-alice.png`.

**Summary**
The naming of the pattern files has been chosen to match the examples in the folder:

https://github.com/jeromeetienne/AR.js/tree/master/three.js/examples/marker-training/examples/pattern-files

e.g. `pattern-letterA.patt`.

The naming of the pattern images has been chosen to match the examples in the folder:

https://github.com/jeromeetienne/AR.js/tree/master/three.js/examples/marker-training/examples/pattern-images

e.g. `pattern-letterA.png`.

**Does this PR introduce a breaking change?**
The change in the function `THREEX.ArPatternFile.triggerDownload` should be transparent to users, as it adds a new parameter with a default value.

**Other information**
