### PR TITLE
add patternRatio to aframe readme

### DIFF
--- a/aframe/README.md
+++ b/aframe/README.md
@@ -35,7 +35,7 @@ include a hatsune miku or minecraft avatar on the marker -->
 | `debugUIEnabled` | true if one should display artoolkit debug canvas, false otherwise |
 | `detectionMode` | the mode of detection - ['color', 'color_and_matrix', 'mono', 'mono_and_matrix'] |
 | `matrixCodeType` | type of matrix code - valid iif detectionMode end with 'matrix' - [3x3, 3x3_HAMMING63, 3x3_PARITY65, 4x4, 4x4_BCH_13_9_3, 4x4_BCH_13_5_5] |
-| `patternRatio` | width of marker borders. |
+| `patternRatio` | width of marker borders |
 | `cameraParametersUrl` | url of the camera parameters |
 | `maxDetectionRate` | tune the maximum rate of pose detection in the source image |
 | `sourceType` | type of source - ['webcam', 'image', 'video'] |

--- a/aframe/README.md
+++ b/aframe/README.md
@@ -17,15 +17,15 @@ Augmented reality for a-frame.
 # Show, Don't Tell
 Here are the demos
 
-- [basic.html](https://jeromeetienne.github.io/AR.js/aframe/examples/basic.html) 
+- [basic.html](https://jeromeetienne.github.io/AR.js/aframe/examples/basic.html)
 basic minimal examples. Good to get started
-<!-- - [demo.html](https://jeromeetienne.github.io/AR.js/aframe/examples/demo.html) 
+<!-- - [demo.html](https://jeromeetienne.github.io/AR.js/aframe/examples/demo.html)
 shows you all the possibilities of aframe-ar. You can play around -->
 - [marker-camera.html](https://jeromeetienne.github.io/AR.js/aframe/examples/marker-camera.html):
 Move the camera instead of using the usual "camera looking toward negative-z and modelViewMatrix"
 - [multiple-independent-markers.html](https://jeromeetienne.github.io/AR.js/aframe/examples/multiple-independent-markers.html):
 Handle multiple indepant markers in a single scene.
-<!-- - [hatsune-minecraft.html](https://jeromeetienne.github.io/AR.js/aframe/examples/minecraft.html): 
+<!-- - [hatsune-minecraft.html](https://jeromeetienne.github.io/AR.js/aframe/examples/minecraft.html):
 include a hatsune miku or minecraft avatar on the marker -->
 
 # artoolkit system
@@ -35,6 +35,7 @@ include a hatsune miku or minecraft avatar on the marker -->
 | `debugUIEnabled` | true if one should display artoolkit debug canvas, false otherwise |
 | `detectionMode` | the mode of detection - ['color', 'color_and_matrix', 'mono', 'mono_and_matrix'] |
 | `matrixCodeType` | type of matrix code - valid iif detectionMode end with 'matrix' - [3x3, 3x3_HAMMING63, 3x3_PARITY65, 4x4, 4x4_BCH_13_9_3, 4x4_BCH_13_5_5] |
+| `patternRatio` | width of marker borders. |
 | `cameraParametersUrl` | url of the camera parameters |
 | `maxDetectionRate` | tune the maximum rate of pose detection in the source image |
 | `sourceType` | type of source - ['webcam', 'image', 'video'] |
@@ -60,7 +61,7 @@ Here are the attributes for this entity
 
 
 # \<a-marker-camera\>
-Usually the model used in augmented reality is about changing the modelViewMatrix 
+Usually the model used in augmented reality is about changing the modelViewMatrix
 based on the marker position. the camera being static in 0,0,0 looking toward negative z.
 
 We define as well a model where we move the camera, instead of the object.
@@ -89,7 +90,7 @@ modelView is able to provide multiple *independent* markers.
 - good collection of [marker patterns](https://github.com/artoolkit/artoolkit5/tree/master/doc/patterns)
 
 # Futures
-- DONE port that into a threex. it is more general. nothing is aframe specific 
+- DONE port that into a threex. it is more general. nothing is aframe specific
 - webar-artoolkit: webvr api with artoolkit as positional tracking
   - demo with a simple scene at 0,0,0 and the camera handled as the phone
   - may be related to the threex thing


### PR DESCRIPTION
<!-- Please don't delete this template or we'll close your issue -->
<!-- All PRs should be done versus 'dev' branch -->
**What kind of change does this PR introduce?**
There is nowhere in the documentation that mentions a patternRatio option. I mentioned in the aframe readme for the artookit system. It will probably need to be explained more in depth elsewhere, but I figured this is a good start.
<!-- Can be a new feature, a bugfix, or refactoring, etc -->
** Can it be referenced to an Issue? If so what is the issue # ?**
https://github.com/jeromeetienne/AR.js/issues/392

**How can we test it?**
spellcheck?
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->
**Summary**
added `patternRatio` attribute to the artoolkit system docs for aframe.
<!-- State here what problem the PR solves and what is the proposed solution -->
**Does this PR introduce a breaking change?**
no

**Other information**
