### PR TITLE
Feature/markergenerator size option

### DIFF
--- a/aframe/README.md
+++ b/aframe/README.md
@@ -17,15 +17,15 @@ Augmented reality for a-frame.
 # Show, Don't Tell
 Here are the demos
 
-- [basic.html](https://jeromeetienne.github.io/AR.js/aframe/examples/basic.html) 
+- [basic.html](https://jeromeetienne.github.io/AR.js/aframe/examples/basic.html)
 basic minimal examples. Good to get started
-<!-- - [demo.html](https://jeromeetienne.github.io/AR.js/aframe/examples/demo.html) 
+<!-- - [demo.html](https://jeromeetienne.github.io/AR.js/aframe/examples/demo.html)
 shows you all the possibilities of aframe-ar. You can play around -->
 - [marker-camera.html](https://jeromeetienne.github.io/AR.js/aframe/examples/marker-camera.html):
 Move the camera instead of using the usual "camera looking toward negative-z and modelViewMatrix"
 - [multiple-independent-markers.html](https://jeromeetienne.github.io/AR.js/aframe/examples/multiple-independent-markers.html):
 Handle multiple indepant markers in a single scene.
-<!-- - [hatsune-minecraft.html](https://jeromeetienne.github.io/AR.js/aframe/examples/minecraft.html): 
+<!-- - [hatsune-minecraft.html](https://jeromeetienne.github.io/AR.js/aframe/examples/minecraft.html):
 include a hatsune miku or minecraft avatar on the marker -->
 
 # artoolkit system
@@ -35,6 +35,7 @@ include a hatsune miku or minecraft avatar on the marker -->
 | `debugUIEnabled` | true if one should display artoolkit debug canvas, false otherwise |
 | `detectionMode` | the mode of detection - ['color', 'color_and_matrix', 'mono', 'mono_and_matrix'] |
 | `matrixCodeType` | type of matrix code - valid iif detectionMode end with 'matrix' - [3x3, 3x3_HAMMING63, 3x3_PARITY65, 4x4, 4x4_BCH_13_9_3, 4x4_BCH_13_5_5] |
+| `patternRatio` | width of marker borders. |
 | `cameraParametersUrl` | url of the camera parameters |
 | `maxDetectionRate` | tune the maximum rate of pose detection in the source image |
 | `sourceType` | type of source - ['webcam', 'image', 'video'] |
@@ -60,7 +61,7 @@ Here are the attributes for this entity
 
 
 # \<a-marker-camera\>
-Usually the model used in augmented reality is about changing the modelViewMatrix 
+Usually the model used in augmented reality is about changing the modelViewMatrix
 based on the marker position. the camera being static in 0,0,0 looking toward negative z.
 
 We define as well a model where we move the camera, instead of the object.
@@ -89,7 +90,7 @@ modelView is able to provide multiple *independent* markers.
 - good collection of [marker patterns](https://github.com/artoolkit/artoolkit5/tree/master/doc/patterns)
 
 # Futures
-- DONE port that into a threex. it is more general. nothing is aframe specific 
+- DONE port that into a threex. it is more general. nothing is aframe specific
 - webar-artoolkit: webvr api with artoolkit as positional tracking
   - demo with a simple scene at 0,0,0 and the camera handled as the phone
   - may be related to the threex thing

--- a/aframe/README.md
+++ b/aframe/README.md
@@ -35,7 +35,6 @@ include a hatsune miku or minecraft avatar on the marker -->
 | `debugUIEnabled` | true if one should display artoolkit debug canvas, false otherwise |
 | `detectionMode` | the mode of detection - ['color', 'color_and_matrix', 'mono', 'mono_and_matrix'] |
 | `matrixCodeType` | type of matrix code - valid iif detectionMode end with 'matrix' - [3x3, 3x3_HAMMING63, 3x3_PARITY65, 4x4, 4x4_BCH_13_9_3, 4x4_BCH_13_5_5] |
-| `patternRatio` | width of marker borders. |
 | `cameraParametersUrl` | url of the camera parameters |
 | `maxDetectionRate` | tune the maximum rate of pose detection in the source image |
 | `sourceType` | type of source - ['webcam', 'image', 'video'] |

--- a/three.js/examples/marker-training/examples/generator.html
+++ b/three.js/examples/marker-training/examples/generator.html
@@ -33,6 +33,11 @@
 		text-decoration: underline;
 	}
 
+	#imageContainer img {
+		width: 100%;
+		max-width: 512px;
+	}
+
 	#topRightButtons {
 		position: fixed;
 		top: 1em;
@@ -102,6 +107,21 @@
 				</div>
 			</div>
 		</div>
+
+		<div class='mdl-grid'>
+			<div class='mdl-cell mdl-cell--3-col'></div>
+
+			<div class='mdl-cell mdl-cell--6-col'>
+				<label class="mdl-js-ripple-effect" for="imageSize">
+					<span class="">Image size 512px</span>
+					<input id='imageSize' class="mdl-slider mdl-js-slider" type="range" min="150" max="2500" value="512" >
+				</label>
+				<div class='mdl-tooltip' for='patternRatioSlider'>
+					Set the pixel width/height of the image.
+				</div>
+			</div>
+		</div>
+
 	</div>
 	<div class='mdl-cell mdl-cell--4-col'>
 		<button id='buttonDownloadEncoded' class='mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent'>
@@ -209,6 +229,16 @@
 		updateFullMarkerImage()
 	})
 
+	document.querySelector('#imageSize').addEventListener('input', function(){
+		// update the patternRatio number
+		var imageSize = document.querySelector('#imageSize').value
+		var domElement = document.querySelector('[for=imageSize] span')
+		domElement.innerHTML = `Image size ${imageSize}px`
+
+		// update fullMarkerImage
+		updateFullMarkerImage()
+	})
+
 
 	document.querySelector('#fileinput').addEventListener('change', function(){
 		var file = this.files[0];
@@ -225,8 +255,9 @@
 	function updateFullMarkerImage(){
 		// get patternRatio
 		var patternRatio = document.querySelector('#patternRatioSlider').value/100
+		var imageSize = document.querySelector('#imageSize').value
 
-		THREEx.ArPatternFile.buildFullMarker(innerImageURL, patternRatio, function onComplete(markerUrl){
+		THREEx.ArPatternFile.buildFullMarker(innerImageURL, patternRatio, imageSize, function onComplete(markerUrl){
 			fullMarkerURL = markerUrl
 
 			var fullMarkerImage = document.createElement('img')

--- a/three.js/examples/marker-training/threex-arpatternfile.js
+++ b/three.js/examples/marker-training/threex-arpatternfile.js
@@ -80,7 +80,7 @@ THREEx.ArPatternFile.triggerDownload =  function(patternFileString){
 	document.body.removeChild(domElement)
 }
 
-THREEx.ArPatternFile.buildFullMarker =  function(innerImageURL, pattRatio, onComplete){
+THREEx.ArPatternFile.buildFullMarker =  function(innerImageURL, pattRatio, size, onComplete){
 	var whiteMargin = 0.1
 	var blackMargin = (1 - 2 * whiteMargin) * ((1-pattRatio)/2)
 	// var blackMargin = 0.2
@@ -89,7 +89,7 @@ THREEx.ArPatternFile.buildFullMarker =  function(innerImageURL, pattRatio, onCom
 
 	var canvas = document.createElement('canvas');
 	var context = canvas.getContext('2d')
-	canvas.width = canvas.height = 512
+	canvas.width = canvas.height = size
 
 	context.fillStyle = 'white';
 	context.fillRect(0,0,canvas.width, canvas.height)


### PR DESCRIPTION
<!-- Please don't delete this template or we'll close your issue -->
<!-- All PRs should be done versus 'dev' branch -->
**What kind of change does this PR introduce?**
It includes a layout change (addition of slider) on the marker generator and a small modification on the `buildFullMarker` function to include the image dimensions as a parameter.
<!-- Can be a new feature, a bugfix, or refactoring, etc -->
** Can it be referenced to an Issue? If so what is the issue # ?**
n/a
**How can we test it?**
upload an image and move the image size slider around. You will be able to see the quality of the image change and you can download the image at whatever dimensions you set it to.
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->
**Summary**
The current marker generator only allows markers to be generated at 512x512 pixels. In this commit, I have added a slider that lets you modify the dimensions of the image for a higher quality marker image.
<!-- State here what problem the PR solves and what is the proposed solution -->
**Does this PR introduce a breaking change?**
no

**Other information**
