### PR TITLE
Move smoothing options to parameters and adjust defaults

### DIFF
--- a/aframe/README.md
+++ b/aframe/README.md
@@ -60,7 +60,7 @@ Here are the attributes for this entity
 | value | value of the barcode - IIF type='barcode' | artoolkitmarker.barcodeValue |
 | preset | parameters preset - ['hiro', 'kanji'] | artoolkitmarker.preset |
 | emitevents | emits 'markerFound' and 'markerLost' events - ['true', 'false'] | - |
-| smooth | turn on/off camera smoothing - ['true', 'false'] - default: true | - |
+| smooth | turn on/off camera smoothing - ['true', 'false'] - default: false | - |
 | smoothCount | number of matrices to smooth tracking over, more = smoother but slower follow - default: 5 | - |
 | smoothTolerance | distance tolerance for smoothing, if smoothThreshold # of matrices are under tolerance, tracking will stay still - default: 0.01 | - |
 | smoothThreshold | threshold for smoothing, will keep still unless enough matrices are over tolerance - default: 2 | - |

--- a/aframe/README.md
+++ b/aframe/README.md
@@ -60,6 +60,10 @@ Here are the attributes for this entity
 | value | value of the barcode - IIF type='barcode' | artoolkitmarker.barcodeValue |
 | preset | parameters preset - ['hiro', 'kanji'] | artoolkitmarker.preset |
 | emitevents | emits 'markerFound' and 'markerLost' events - ['true', 'false'] | - |
+| smooth | turn on/off camera smoothing - ['true', 'false'] - default: true | - |
+| smoothCount | number of matrices to smooth tracking over, more = smoother but slower follow - default: 5 | - |
+| smoothTolerance | distance tolerance for smoothing, if smoothThreshold # of matrices are under tolerance, tracking will stay still - default: 0.01 | - |
+| smoothThreshold | threshold for smoothing, will keep still unless enough matrices are over tolerance - default: 2 | - |
 
 
 # \<a-marker-camera\>

--- a/aframe/src/component-anchor.js
+++ b/aframe/src/component-anchor.js
@@ -36,7 +36,7 @@ AFRAME.registerComponent('arjs-anchor', {
 		},
 		smooth: {
 			type: 'boolean',
-			default: true,
+			default: false,
 		},
 		smoothCount: {
 			type: 'number',

--- a/aframe/src/component-anchor.js
+++ b/aframe/src/component-anchor.js
@@ -211,6 +211,10 @@ AFRAME.registerPrimitive('a-anchor', AFRAME.utils.extendDeep({}, AFRAME.primitiv
 		'preset': 'arjs-anchor.preset',
 		'minConfidence': 'arjs-anchor.minConfidence',
 		'markerhelpers': 'arjs-anchor.markerhelpers',
+		'smooth': 'arjs-anchor.smooth',
+		'smoothCount': 'arjs-anchor.smoothCount',
+		'smoothTolerance': 'arjs-anchor.smoothTolerance',
+		'smoothThreshold': 'arjs-anchor.smoothThreshold',
 
 		'hit-testing-renderDebug': 'arjs-hit-testing.renderDebug',
 		'hit-testing-enabled': 'arjs-hit-testing.enabled',
@@ -244,6 +248,10 @@ AFRAME.registerPrimitive('a-marker', AFRAME.utils.extendDeep({}, AFRAME.primitiv
 		'preset': 'arjs-anchor.preset',
 		'minConfidence': 'arjs-anchor.minConfidence',
 		'markerhelpers': 'arjs-anchor.markerhelpers',
+		'smooth': 'arjs-anchor.smooth',
+		'smoothCount': 'arjs-anchor.smoothCount',
+		'smoothTolerance': 'arjs-anchor.smoothTolerance',
+		'smoothThreshold': 'arjs-anchor.smoothThreshold',
 
 		'hit-testing-renderDebug': 'arjs-hit-testing.renderDebug',
 		'hit-testing-enabled': 'arjs-hit-testing.enabled',

--- a/aframe/src/component-anchor.js
+++ b/aframe/src/component-anchor.js
@@ -34,6 +34,22 @@ AFRAME.registerComponent('arjs-anchor', {
 			type: 'number',
 			default: 0.6,
 		},
+		smooth: {
+			type: 'boolean',
+			default: true,
+		},
+		smoothCount: {
+			type: 'number',
+			default: 5,
+		},
+		smoothTolerance: {
+			type: 'number',
+			default: 0.01,
+		},
+		smoothThreshold: {
+			type: 'number',
+			default: 2,
+		},
 	},
 	init: function () {
 		var _this = this
@@ -100,6 +116,11 @@ AFRAME.registerComponent('arjs-anchor', {
 			}else {
 				// console.assert( this.data.preset === '', 'illegal preset value '+this.data.preset)
 			}
+
+			markerParameters.smooth = _this.data.smooth;
+			markerParameters.smoothCount = _this.data.smoothCount;
+			markerParameters.smoothTolerance = _this.data.smoothTolerance;
+			markerParameters.smoothThreshold = _this.data.smoothThreshold;
 
 			//////////////////////////////////////////////////////////////////////////////
 			//		create arAnchor

--- a/three.js/README.md
+++ b/three.js/README.md
@@ -30,6 +30,14 @@ var parameters = {
 	barcodeValue : null,
 	// change matrix mode - [modelViewMatrix, cameraTransformMatrix]
 	changeMatrixMode : 'modelViewMatrix',
+	// turn on/off camera smoothing
+	smooth: true,
+	// number of matrices to smooth tracking over, more = smoother but slower follow
+	smoothCount: 5,
+	// distance tolerance for smoothing, if smoothThreshold # of matrices are under tolerance, tracking will stay still
+	smoothTolerance: 0.01,
+	// threshold for smoothing, will keep still unless enough matrices are over tolerance
+	smoothThreshold: 2,
 }
 ```
 

--- a/three.js/src/threex/threex-armarkercontrols.js
+++ b/three.js/src/threex/threex-armarkercontrols.js
@@ -22,7 +22,7 @@ ARjs.MarkerControls = THREEx.ArMarkerControls = function(context, object3d, para
 		// minimal confidence in the marke recognition - between [0, 1] - default to 1
 		minConfidence: 0.6,
 		// turn on/off camera smoothing
-		smooth: true,
+		smooth: false,
 		// number of matrices to smooth tracking over, more = smoother but slower follow
 		smoothCount: 5,
 		// distance tolerance for smoothing, if smoothThreshold # of matrices are under tolerance, tracking will stay still


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Mainly moved smoothing options from constants to parameters, added ability to turn off smoothing, and tweaked the default options for smoothing to be less aggressive.

More detailed:
- add smooth flag so user can turn off smoothing, but enabled it by default
- moved DEBOUNCE_COUNT constant to parameters as smoothCount, changed default from 10 to 4
- moved AVERAGE_MATRIX_TOLERANCE to parameters as smoothTolerance, default is still 0.01
- moved AVERAGE_MATRIX_THRESHOLD to parameters as smoothThreshold, changed default from 5 to 2

**Can it be referenced to an Issue? If so what is the issue # ?**
This is related to PR #422 

**How can we test it?**
Try turning on and off smoothing with the `smooth` parameter.
Try different values for `smoothCount`, `smoothTolerance`, `smoothThreshold`.

**Summary**
The previous implementation of marker smoothing hardcoded its parameters, and was implemented to always be on no matter what. This PR gives the user more control over smoothing.

**Does this PR introduce a breaking change?**
Yes, but the previous PR was also a breaking change which has not been released to master or an AR.js build yet, so this can be considered an extension of #422.
