### PR TITLE
CubeGeometry => BoxGeometry

### DIFF
--- a/three.js/examples/mobile-performance.html
+++ b/three.js/examples/mobile-performance.html
@@ -132,7 +132,7 @@
 	var arWorldRoot = smoothedRoot
 
 	// add a torus knot	
-	var geometry	= new THREE.CubeGeometry(1,1,1);
+	var geometry	= new THREE.BoxGeometry(1,1,1);
 	var material	= new THREE.MeshNormalMaterial({
 		transparent : true,
 		opacity: 0.5,


### PR DESCRIPTION
CubeGeometry is just an alias and throws error when using Three.d.ts definition file

<!-- Please don't delete this template or we'll close your issue -->
<!-- All PRs should be done versus 'dev' branch -->
**What kind of change does this PR introduce?**
cleanup
<!-- Can be a new feature, a bugfix, or refactoring, etc -->
**Can it be referenced to an Issue? If so what is the issue # ?**
cleanup

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->
**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->
**Does this PR introduce a breaking change?**

**Other information**
