### PR TITLE
Update component-anchor.js

### DIFF
--- a/aframe/demos/demo-minecraft-launch-demo/minecraft.html
+++ b/aframe/demos/demo-minecraft-launch-demo/minecraft.html
@@ -16,7 +16,7 @@
 </div>
         <a-scene embedded arjs='sourceType: image; sourceUrl:../../../data/images/armchair.jpg; detectionMode: mono_and_matrix;' antialias="true">        
 
-		<a-marker type='unknown' minConfidence='0'>                
+		<a-marker type='unknown' min-confidence='0'>
 		<!-- <a-marker type='pattern' url='../../data/data/patt.hiro' size='1'> -->
 	                <!-- Add a minecraft character -->
 	                <a-minecraft></a-minecraft>

--- a/aframe/src/component-anchor.js
+++ b/aframe/src/component-anchor.js
@@ -209,14 +209,14 @@ AFRAME.registerPrimitive('a-anchor', AFRAME.utils.extendDeep({}, AFRAME.primitiv
 		'url': 'arjs-anchor.patternUrl',
 		'value': 'arjs-anchor.barcodeValue',
 		'preset': 'arjs-anchor.preset',
-		'minConfidence': 'arjs-anchor.minConfidence',
-		'markerhelpers': 'arjs-anchor.markerhelpers',
+		'min-confidence': 'arjs-anchor.minConfidence',
+		'marker-helpers': 'arjs-anchor.markerhelpers',
 		'smooth': 'arjs-anchor.smooth',
-		'smoothCount': 'arjs-anchor.smoothCount',
-		'smoothTolerance': 'arjs-anchor.smoothTolerance',
-		'smoothThreshold': 'arjs-anchor.smoothThreshold',
+		'smooth-count': 'arjs-anchor.smoothCount',
+		'smooth-tolerance': 'arjs-anchor.smoothTolerance',
+		'smooth-threshold': 'arjs-anchor.smoothThreshold',
 
-		'hit-testing-renderDebug': 'arjs-hit-testing.renderDebug',
+		'hit-testing-render-debug': 'arjs-hit-testing.renderDebug',
 		'hit-testing-enabled': 'arjs-hit-testing.enabled',
 	}
 }))
@@ -246,14 +246,14 @@ AFRAME.registerPrimitive('a-marker', AFRAME.utils.extendDeep({}, AFRAME.primitiv
 		'url': 'arjs-anchor.patternUrl',
 		'value': 'arjs-anchor.barcodeValue',
 		'preset': 'arjs-anchor.preset',
-		'minConfidence': 'arjs-anchor.minConfidence',
-		'markerhelpers': 'arjs-anchor.markerhelpers',
+		'min-confidence': 'arjs-anchor.minConfidence',
+		'marker-helpers': 'arjs-anchor.markerhelpers',
 		'smooth': 'arjs-anchor.smooth',
-		'smoothCount': 'arjs-anchor.smoothCount',
-		'smoothTolerance': 'arjs-anchor.smoothTolerance',
-		'smoothThreshold': 'arjs-anchor.smoothThreshold',
+		'smooth-count': 'arjs-anchor.smoothCount',
+		'smooth-tolerance': 'arjs-anchor.smoothTolerance',
+		'smooth-threshold': 'arjs-anchor.smoothThreshold',
 
-		'hit-testing-renderDebug': 'arjs-hit-testing.renderDebug',
+		'hit-testing-render-debug': 'arjs-hit-testing.renderDebug',
 		'hit-testing-enabled': 'arjs-hit-testing.enabled',
 	}
 }))
@@ -271,7 +271,7 @@ AFRAME.registerPrimitive('a-marker-camera', AFRAME.utils.extendDeep({}, AFRAME.p
 		'url': 'arjs-anchor.patternUrl',
 		'value': 'arjs-anchor.barcodeValue',
 		'preset': 'arjs-anchor.preset',
-		'minConfidence': 'arjs-anchor.minConfidence',
-		'markerhelpers': 'arjs-anchor.markerhelpers',
+		'min-confidence': 'arjs-anchor.minConfidence',
+		'marker-helpers': 'arjs-anchor.markerhelpers',
 	}
 }))


### PR DESCRIPTION
**What kind of change does this PR introduce?**
renamed the html-mappings to lower case variants to avoid warnings in certain browsers.

**Can it be referenced to an Issue? If so what is the issue # ?**
No, since this fixes merely a warning.

**How can we test it?**
Open developer-tools console. Warnings of the type  `extras:primitives:warn Mapping keys should be specified in lower case.` shouldn't appear anymore.

**Summary**
fixed `extras:primitives:warn Mapping keys should be specified in lower case.` - warning by renaming the mappings to lower case.

**Does this PR introduce a breaking change?**
It requires projects to use the new lower-case variants of the html-mappings:

| before | now |
| --- | --- |
|`minConfidence` | `min-confidence` |
|`markerhelpers` | `marker-helpers` |
|`smoothCount` | `smooth-count` |
|`smoothTolerance` | `smooth-tolerance` |
|`smoothThreshold` | `smooth-threshold` |
|`hit-testing-renderDebug` | `hit-testing-render-debug` |

It might break the minecraft-launch-demo, since it uses `minConfidence='0'` in it's  `<a-marker>`: https://github.com/jeromeetienne/AR.js/blob/32fe9c0e121057c7b2b2ec40588457c23cd4cdd7/aframe/demos/demo-minecraft-launch-demo/minecraft.html#L19

**Other information**
Despite HTML5 allows mixing uppercase and lowercase letters in attribute names, it's widely recommended to use lowercase attribute names, since stricter document types like XHTML demand lowercase.