### PR TITLE
Update version on package.json and on console logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ar.js",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Efficient Augmented Reality for the Web",
   "main": "",
   "scripts": {

--- a/three.js/src/threex/threex-artoolkitcontext.js
+++ b/three.js/src/threex/threex-artoolkitcontext.js
@@ -1,3 +1,5 @@
+import *  as PACKAGE from '../../../package.json';
+
 var ARjs = ARjs || {}
 var THREEx = THREEx || {}
 
@@ -76,9 +78,7 @@ Object.assign( ARjs.Context.prototype, THREE.EventDispatcher.prototype );
 // ARjs.Context.baseURL = '../'
 // default to github page
 ARjs.Context.baseURL = 'https://jeromeetienne.github.io/AR.js/three.js/'
-ARjs.Context.REVISION = '1.6.2'
-
-
+ARjs.Context.REVISION = PACKAGE.version;
 
 /**
  * Create a default camera for this trackingBackend


### PR DESCRIPTION
<!-- Please don't delete this template or we'll close your issue -->
<!-- All PRs should be done versus 'dev' branch -->

There is a log in console when loading AR.js. It is misleading as it shows now '1.6.2' version. The problem is that it has to be manually updated: it is hardcoded on three.js file.

So, I first update the package.json version (from 1.6.2 to 1.7.0, current ver) and then imported the version from package.json in order to log it directly, so it will be always aligned.

**Can be a new feature, a bugfix, or refactoring, etc**
No, just an enhancements. Have to push that on master for a release. Then align dev, that is behind master for other modifies (templates, .md files, etc.).

**Does this PR introduce a breaking change?**
No

**Other information**
