### PR TITLE
Enable custom area markers and a custom learner url

### DIFF
--- a/aframe/src/component-anchor.js
+++ b/aframe/src/component-anchor.js
@@ -22,6 +22,7 @@ AFRAME.registerComponent('arjs-anchor', {
 		},
 		patternUrl: {
 			type: 'string',
+			default: '',
 		},
 		barcodeValue: {
 			type: 'number'
@@ -99,8 +100,12 @@ AFRAME.registerComponent('arjs-anchor', {
 				markerParameters.patternUrl = THREEx.ArToolkitContext.baseURL+'examples/marker-training/examples/pattern-files/pattern-kanji.patt'
 				markerParameters.markersAreaEnabled = false
 			}else if( _this.data.preset === 'area' ){
-				markerParameters.type = 'barcode'
-				markerParameters.barcodeValue = 1001
+				if (_this.data.patternUrl !== '') {
+					markerParameters.patternUrl = _this.data.patternUrl
+				} else {
+					markerParameters.type = 'barcode'
+					markerParameters.barcodeValue = 1001
+				}
 				markerParameters.markersAreaEnabled = true
 			}else if( _this.data.type === 'barcode' ){
 				markerParameters = {

--- a/aframe/src/system-arjs.js
+++ b/aframe/src/system-arjs.js
@@ -83,6 +83,10 @@ AFRAME.registerSystem('arjs', {
 			type: 'number',
 			default: -1
 		},
+		areaLearnerUrl : {
+			type: 'string',
+			default: ''
+		},
 	},
 
 	//////////////////////////////////////////////////////////////////////////////
@@ -238,6 +242,9 @@ AFRAME.registerSystem('arjs', {
 				// create sessionDebugUI
 				var sessionDebugUI = new ARjs.SessionDebugUI(arSession)
 				containerElement.appendChild(sessionDebugUI.domElement)
+
+				// set the learner url if provided
+				if ( _this.data.areaLearnerUrl !== '' ) ARjs.AnchorDebugUI.MarkersAreaLearnerURL = _this.data.areaLearnerUrl
 			}
 		})
 

--- a/three.js/src/markers-area/threex-armultimarkerutils.js
+++ b/three.js/src/markers-area/threex-armultimarkerutils.js
@@ -13,13 +13,14 @@ ARjs.MarkersAreaUtils = THREEx.ArMultiMarkerUtils = {}
  * Navigate to the multi-marker learner page
  * 
  * @param {String} learnerBaseURL  - the base url for the learner
+ * @param {String} pattern urls separated with a comma
  * @param {String} trackingBackend - the tracking backend to use
  */
-ARjs.MarkersAreaUtils.navigateToLearnerPage = function(learnerBaseURL, trackingBackend){
+ARjs.MarkersAreaUtils.navigateToLearnerPage = function(learnerBaseURL, trackingBackend, patternUrls){
 	var learnerParameters = {
 		backURL : location.href,
 		trackingBackend: trackingBackend,
-		markersControlsParameters: ARjs.MarkersAreaUtils.createDefaultMarkersControlsParameters(trackingBackend),
+		markersControlsParameters: ARjs.MarkersAreaUtils.createMarkersControlsParameters(trackingBackend, patternUrls),
 	}
 	location.href = learnerBaseURL + '?' + encodeURIComponent(JSON.stringify(learnerParameters))
 }
@@ -82,6 +83,37 @@ ARjs.MarkersAreaUtils.createDefaultMultiMarkerFile = function(trackingBackend){
 	// json.strinfy the value and store it in localStorage
 	return file
 }
+
+//////////////////////////////////////////////////////////////////////////////
+//		createMarkersControlsParameters
+//////////////////////////////////////////////////////////////////////////////
+
+ /**
+ * Create controls parameters for the multi-marker learner. If no urls provided, use defaults
+ *
+ * @param {String} trackingBackend - the tracking backend to use
+ * @param {String} pattern urls separated with a comma
+ * @return {Object} - json object containing the controls parameters
+ */
+ARjs.MarkersAreaUtils.createMarkersControlsParameters = function(trackingBackend, patternUrls) {
+	// if there is no url list - use the defaults
+	if ( !patternUrls || patternUrls.indexOf(',') === -1 ) {
+		return ARjs.MarkersAreaUtils.createDefaultMarkersControlsParameters(trackingBackend)
+	}
+
+	// if there is a list specified - use the urls to create a custom markerControlsParameters object
+	var markerControlsParameters = []
+	var urlList = patternUrls.split(",")
+	urlList.forEach(function (url) {
+		var markerControlsParameterObject = {
+			type : 'pattern',
+			patternUrl : url,
+		}
+		markerControlsParameters.push(markerControlsParameterObject)
+	})
+	return markerControlsParameters
+}
+
 
 //////////////////////////////////////////////////////////////////////////////
 //		createDefaultMarkersControlsParameters

--- a/three.js/src/new-api/arjs-debugui.js
+++ b/three.js/src/new-api/arjs-debugui.js
@@ -164,7 +164,7 @@ ARjs.AnchorDebugUI = function(arAnchor){
 			}else{
 				var learnerURL = ARjs.Context.baseURL + 'examples/multi-markers/examples/learner.html'
 			}
-			ARjs.MarkersAreaUtils.navigateToLearnerPage(learnerURL, trackingBackend)
+			ARjs.MarkersAreaUtils.navigateToLearnerPage(learnerURL, trackingBackend, arAnchor.parameters.patternUrl)
 		})	
 	}
 

--- a/three.js/src/new-api/arjs-debugui.js
+++ b/three.js/src/new-api/arjs-debugui.js
@@ -3,75 +3,53 @@ var ARjs = ARjs || {}
 
 /**
  * Create an debug UI for an ARjs.Anchor
- * 
+ *
  * @param {ARjs.Anchor} arAnchor - the anchor to user
  */
-ARjs.SessionDebugUI = function(arSession, tangoPointCloud){
-	var trackingBackend = arSession.arContext.parameters.trackingBackend
+ARjs.SessionDebugUI = function (arSession, tangoPointCloud) {
+    var trackingBackend = arSession.arContext.parameters.trackingBackend
 
-	this.domElement = document.createElement('div')
-	this.domElement.style.color = 'rgba(0,0,0,0.9)'
-	this.domElement.style.backgroundColor = 'rgba(127,127,127,0.5)'
-	this.domElement.style.display = 'inline-block'
-	this.domElement.style.padding = '0.5em'
-	this.domElement.style.margin = '0.5em'
-	this.domElement.style.textAlign = 'left'
+    this.domElement = document.createElement('div')
+    this.domElement.style.color = 'rgba(0,0,0,0.9)'
+    this.domElement.style.backgroundColor = 'rgba(127,127,127,0.5)'
+    this.domElement.style.display = 'block'
+    this.domElement.style.padding = '0.5em'
+    this.domElement.style.position = 'fixed'
+    this.domElement.style.left = '5px'
+    this.domElement.style.bottom = '10px'
+    this.domElement.style.textAlign = 'right'
 
-	//////////////////////////////////////////////////////////////////////////////
-	//		add title
-	//////////////////////////////////////////////////////////////////////////////
-	// var domElement = document.createElement('div')
-	// domElement.style.display = 'block'
-	// domElement.style.fontWeight = 'bold'
-	// domElement.style.fontSize = '120%'
-	// this.domElement.appendChild(domElement)
-	// domElement.innerHTML = 'AR.js Session Debug'
+    //////////////////////////////////////////////////////////////////////////////
+    //		current-tracking-backend
+    //////////////////////////////////////////////////////////////////////////////
 
-	//////////////////////////////////////////////////////////////////////////////
-	//		current-tracking-backend
-	//////////////////////////////////////////////////////////////////////////////
+    var domElement = document.createElement('span')
+    domElement.style.display = 'block'
+    domElement.innerHTML = '<b>trackingBackend</b> : ' + trackingBackend
+    this.domElement.appendChild(domElement)
 
-	var domElement = document.createElement('span')
-	domElement.style.display = 'block'
-	this.domElement.appendChild(domElement)
-	domElement.innerHTML = '<b>trackingBackend</b> : ' +trackingBackend
-	
-	//////////////////////////////////////////////////////////////////////////////
-	//		augmented-websites
-	//////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////
+    //		toggle-point-cloud
+    //////////////////////////////////////////////////////////////////////////////
 
-	if( ARjs.SessionDebugUI.AugmentedWebsiteURL ){
-		var domElement = document.createElement('a')
-		domElement.innerHTML = 'Share on augmented-websites'
-		domElement.style.display = 'block'
-		// domElement.setAttribute('target', '_blank')
-		domElement.href = ARjs.SessionDebugUI.AugmentedWebsiteURL + '?'+location.href
-		this.domElement.appendChild(domElement)						
-	}
+    if (trackingBackend === 'tango' && tangoPointCloud) {
+        var domElement = document.createElement('button')
+        this.domElement.appendChild(domElement)
 
-	//////////////////////////////////////////////////////////////////////////////
-	//		toggle-point-cloud
-	//////////////////////////////////////////////////////////////////////////////
+        domElement.id = 'buttonTangoTogglePointCloud'
+        domElement.innerHTML = 'toggle-point-cloud'
+        domElement.href = 'javascript:void(0)'
 
-	if( trackingBackend === 'tango' && tangoPointCloud ){
-		var domElement = document.createElement('button')
-		this.domElement.appendChild(domElement)
+        domElement.addEventListener('click', function () {
+            var scene = arSession.parameters.scene
 
-		domElement.id= 'buttonTangoTogglePointCloud'
-		domElement.innerHTML = 'toggle-point-cloud'
-		domElement.href='javascript:void(0)'
-
-		domElement.addEventListener('click', function(){
-			var scene = arSession.parameters.scene
-	// TODO how tangoPointCloud, get connected here ???
-	// in arguments simply ?
-			if( tangoPointCloud.object3d.parent ){
-				scene.remove(tangoPointCloud.object3d)
-			}else{
-				scene.add(tangoPointCloud.object3d)			
-			}
-		})
-	}
+            if (tangoPointCloud.object3d.parent) {
+                scene.remove(tangoPointCloud.object3d)
+            } else {
+                scene.add(tangoPointCloud.object3d)
+            }
+        })
+    }
 }
 
 /**
@@ -84,108 +62,103 @@ ARjs.SessionDebugUI.AugmentedWebsiteURL = 'https://webxr.io/augmented-website'
 //		ARjs.AnchorDebugUI
 //////////////////////////////////////////////////////////////////////////////
 
-
-
-
 /**
  * Create an debug UI for an ARjs.Anchor
- * 
+ *
  * @param {ARjs.Anchor} arAnchor - the anchor to user
  */
-ARjs.AnchorDebugUI = function(arAnchor){
-	var _this = this 
-	var arSession = arAnchor.arSession
-	var trackingBackend = arSession.arContext.parameters.trackingBackend
-	
-	this.domElement = document.createElement('div')
-	this.domElement.style.color = 'rgba(0,0,0,0.9)'
-	this.domElement.style.backgroundColor = 'rgba(127,127,127,0.5)'
-	this.domElement.style.display = 'inline-block'
-	this.domElement.style.padding = '0.5em'
-	this.domElement.style.margin = '0.5em'
-	this.domElement.style.textAlign = 'left'
+ARjs.AnchorDebugUI = function (arAnchor) {
+    var arSession = arAnchor.arSession
+    var trackingBackend = arSession.arContext.parameters.trackingBackend
 
-	//////////////////////////////////////////////////////////////////////////////
-	//		add title
-	//////////////////////////////////////////////////////////////////////////////
+    this.domElement = document.createElement('div')
+    this.domElement.style.color = 'rgba(0,0,0,0.9)'
+    this.domElement.style.backgroundColor = 'rgba(127,127,127,0.5)'
+    this.domElement.style.display = 'inline-block'
+    this.domElement.style.padding = '0.5em'
+    this.domElement.style.margin = '0.5em'
+    this.domElement.style.textAlign = 'left'
 
-	// var domElement = document.createElement('div')
-	// domElement.style.display = 'block'
-	// domElement.style.fontWeight = 'bold'
-	// domElement.style.fontSize = '120%'
-	// this.domElement.appendChild(domElement)
-	// domElement.innerHTML = 'Anchor Marker Debug'
+    //////////////////////////////////////////////////////////////////////////////
+    //		current-tracking-backend
+    //////////////////////////////////////////////////////////////////////////////
 
-	//////////////////////////////////////////////////////////////////////////////
-	//		current-tracking-backend
-	//////////////////////////////////////////////////////////////////////////////
+    var domElement = document.createElement('span')
+    domElement.style.display = 'block'
+    domElement.style.padding = '0.5em'
+    domElement.style.color = 'rgba(0,0,0,0.9)'
+    domElement.style.backgroundColor = 'rgba(127,127,127,0.5)'
+    domElement.style.position = 'fixed'
+    domElement.style.left = '5px'
+    domElement.style.bottom = '40px'
 
-	var domElement = document.createElement('span')
-	domElement.style.display = 'block'
-	this.domElement.appendChild(domElement)
-	domElement.innerHTML = '<b>markersAreaEnabled</b> :' +arAnchor.parameters.markersAreaEnabled
+    this.domElement.appendChild(domElement)
+    domElement.innerHTML = '<b>markersAreaEnabled</b> :' + arAnchor.parameters.markersAreaEnabled
 
-	//////////////////////////////////////////////////////////////////////////////
-	//		toggle-marker-helper
-	//////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////
+    //		toggle-marker-helper
+    //////////////////////////////////////////////////////////////////////////////
 
-	if( arAnchor.parameters.markersAreaEnabled ){
-		var domElement = document.createElement('button')
-		domElement.style.display = 'block'
-		this.domElement.appendChild(domElement)
+    if (arAnchor.parameters.markersAreaEnabled) {
+        var domElement = document.createElement('button')
+        domElement.style.display = 'block'
+        this.domElement.style.padding = '0.5em'
+        this.domElement.style.position = 'fixed'
+        this.domElement.style.textAlign = 'left'
+        this.domElement.appendChild(domElement)
 
-		domElement.id= 'buttonToggleMarkerHelpers'
-		domElement.innerHTML = 'toggle-marker-helper'
-		domElement.href='javascript:void(0)'
+        domElement.id = 'buttonToggleMarkerHelpers'
+        domElement.innerHTML = 'toggle-marker-helper'
+        domElement.href = 'javascript:void(0)'
 
-		var subMarkerHelpersVisible = false
-		domElement.addEventListener('click', function(){
-			subMarkerHelpersVisible = subMarkerHelpersVisible ? false : true
-			arAnchor.markersArea.setSubMarkersVisibility(subMarkerHelpersVisible)		
-		})
-	}
-	
-	//////////////////////////////////////////////////////////////////////////////
-	//		Learn-new-marker-area
-	//////////////////////////////////////////////////////////////////////////////
+        var subMarkerHelpersVisible = false
+        domElement.addEventListener('click', function () {
+            subMarkerHelpersVisible = subMarkerHelpersVisible ? false : true
+            arAnchor.markersArea.setSubMarkersVisibility(subMarkerHelpersVisible)
+        })
+    }
 
-	if( arAnchor.parameters.markersAreaEnabled ){
-		var domElement = document.createElement('button')
-		domElement.style.display = 'block'
-		this.domElement.appendChild(domElement)
+    //////////////////////////////////////////////////////////////////////////////
+    //		Learn-new-marker-area
+    //////////////////////////////////////////////////////////////////////////////
 
-		domElement.id = 'buttonMarkersAreaLearner'
-		domElement.innerHTML = 'Learn-new-marker-area'
-		domElement.href ='javascript:void(0)'
+    if (arAnchor.parameters.markersAreaEnabled) {
+        var domElement = document.createElement('button')
+        domElement.style.display = 'block'
+        this.domElement.appendChild(domElement)
 
-		domElement.addEventListener('click', function(){
-			if( ARjs.AnchorDebugUI.MarkersAreaLearnerURL !== null ){
-				var learnerURL = ARjs.AnchorDebugUI.MarkersAreaLearnerURL
-			}else{
-				var learnerURL = ARjs.Context.baseURL + 'examples/multi-markers/examples/learner.html'
-			}
-			ARjs.MarkersAreaUtils.navigateToLearnerPage(learnerURL, trackingBackend, arAnchor.parameters.patternUrl)
-		})	
-	}
+        domElement.id = 'buttonMarkersAreaLearner'
+        domElement.innerHTML = 'Learn-new-marker-area'
+        domElement.href = 'javascript:void(0)'
 
-	//////////////////////////////////////////////////////////////////////////////
-	//		Reset-marker-area
-	//////////////////////////////////////////////////////////////////////////////
+        domElement.addEventListener('click', function () {
+            if (ARjs.AnchorDebugUI.MarkersAreaLearnerURL !== null) {
+                var learnerURL = ARjs.AnchorDebugUI.MarkersAreaLearnerURL
+            } else {
+                var learnerURL = ARjs.Context.baseURL + 'examples/multi-markers/examples/learner.html'
+            }
+           	ARjs.MarkersAreaUtils.navigateToLearnerPage(learnerURL, trackingBackend, arAnchor.parameters.patternUrl)
+        })
+    }
 
-	if( arAnchor.parameters.markersAreaEnabled ){
-		var domElement = document.createElement('button')
-		domElement.style.display = 'block'
-		this.domElement.appendChild(domElement)
+    //////////////////////////////////////////////////////////////////////////////
+    //		Reset-marker-area
+    //////////////////////////////////////////////////////////////////////////////
 
-		domElement.id = 'buttonMarkersAreaReset'
-		domElement.innerHTML = 'Reset-marker-area'
-		domElement.href ='javascript:void(0)'
+    if (arAnchor.parameters.markersAreaEnabled) {
+        var domElement = document.createElement('button')
+        domElement.style.display = 'block'
+        this.domElement.appendChild(domElement)
 
-		domElement.addEventListener('click', function(){
-			ARjs.MarkersAreaUtils.storeDefaultMultiMarkerFile(trackingBackend)
-			location.reload()
-		})
-	}
+        domElement.id = 'buttonMarkersAreaReset'
+        domElement.innerHTML = 'Reset-marker-area'
+        domElement.href = 'javascript:void(0)'
+
+        domElement.addEventListener('click', function () {
+            ARjs.MarkersAreaUtils.storeDefaultMultiMarkerFile(trackingBackend)
+            location.reload()
+        })
+    }
 }
 
 /**


### PR DESCRIPTION
<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
<!-- Can be a new feature, a bugfix, or refactoring, etc -->

This PR enables:
- defining a custom learner url via the a-frame schema
- using custom urls for a marker area 

**Can it be referenced to an Issue? If so what is the issue # ?**
- hardcoded pattern urls for a marker area: #283 
- custom learner url: #405 

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->

I've pushed the build into [another branch](https://github.com/gftruj/AR.js/tree/enable-custom-area-markers-build) and used the source code in this [glitch](https://glitch.com/~aframear-customarea). It contains the custom patterns for an area and a custom learner url. Let me know how would you like me to test this.

**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->
**1) Custom marker area**

Using both aframe and three.js - the marker parameters are combined into the URL within the 
[navigateToLearnerPage](https://github.com/jeromeetienne/AR.js/blob/master/three.js/src/markers-area/threex-armultimarkerutils.js#L18-L24) function. 

I've added a function which determines whether the user provided a list of urls to the patterns, or the default markers should be generated .

a) When using the aframe API, the idea is mostly to use the existing `patternUrl` property:

    <a-scene arjs='debugUIEnabled: true; areaLearnerUrl: learner.html'>
		  <a-marker preset="area" url="one.patt, two.patt, three.patt">
which is grabbed by the arjs-debugui - and used when navigated to learner page.

b) In the three.js ([player example](https://github.com/jeromeetienne/AR.js/blob/master/three.js/examples/multi-markers/examples/player.html#L224)) the method is called directly - so you can simply do:
   
    THREEx.ArMultiMarkerUtils.navigateToLearnerPage('learner.html', urlOptions.trackingBackend, 'one.patt, two.patt, three.patt')

**2) Custom learner url**

The url could be changed [here](https://github.com/jeromeetienne/AR.js/blob/master/three.js/src/new-api/arjs-debugui.js#L165), if you'd like, but
- the official example does not even use the built in path ( 1.b function call - already contains a custom url)
- the builds are not always '../../' from the root (the portable version ?)
- in three.js you can simply have a neat definition
`<script>THREEx.ArToolkitContext.baseURL = '../../../'</script>`
- in a-frame it would be better to define a url in the schema instead of throwing in scripts - hence the commit

**Does this PR introduce a breaking change?**
No

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**
The provided glitch is working on:
-Ubuntu 18.04 Firefox 67.0.4 (64-bit)
-Android Firefox 67.0.3
-Windows 10 chrome 75.0.3770.100

**Other information**
