### PR TITLE
Camera 0 is now used for the default AR camera

### DIFF
--- a/aframe/build/aframe-ar.js
+++ b/aframe/build/aframe-ar.js
@@ -6027,31 +6027,65 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
 
 	// get available devices
 	navigator.mediaDevices.enumerateDevices().then(function(devices) {
-                var userMediaConstraints = {
-			audio: false,
-			video: {
-				facingMode: 'environment',
-				width: {
-					ideal: _this.parameters.sourceWidth,
-					// min: 1024,
-					// max: 1920
-				},
-				height: {
-					ideal: _this.parameters.sourceHeight,
-					// min: 776,
-					// max: 1080
+
+		var deviceToUse = "";
+		var deviceLabel = ""; //Used to check if permissions have been accepted, enumerateDevices() runs without needing to accept permissions
+		var isAndroid = false;
+		//For android phones
+		for(var i = 0; i < devices.length; i++){
+			deviceLabel = devices[i].label;
+			if(devices[i].kind === "videoinput"){
+				if(devices[i].label.includes("0")){
+					deviceToUse = devices[i].deviceId;
+					isAndroid = true;
+					break;
 				}
-		  	}
+			}
+		}
+		//For Iphones
+		if(isAndroid === false){
+			for(var i = 0; i < devices.length; i++){
+				if(devices[i].kind === "videoinput"){
+					if(devices[i].label.includes("Back")){
+						deviceToUse = devices[i].deviceId;
+						break;
+					}
+				}
+			}
 		}
 
-		if (null !== _this.parameters.deviceId) {
-			userMediaConstraints.video.deviceId = {
-				exact: _this.parameters.deviceId
+		var userMediaConstraints;
+		if(deviceToUse !== ""){
+			userMediaConstraints = {
+			audio: false,
+				video: {
+					deviceId : deviceToUse
+				}
+			};
+		}else{
+			userMediaConstraints = {
+				audio: false,
+				video: {
+					facingMode: 'environment',
+					width: {
+						ideal: _this.parameters.sourceWidth,
+						// min: 1024,
+						// max: 1920
+					},
+					height: {
+						ideal: _this.parameters.sourceHeight,
+						// min: 776,
+						// max: 1080
+					}
+				}
 			};
 		}
-
 		// get a device which satisfy the constraints
 		navigator.mediaDevices.getUserMedia(userMediaConstraints).then(function success(stream) {
+			//If permissions have been accepted for the first time, device label will show as ""
+			if(deviceLabel === ""){
+				location.reload();
+			}
 			// set the .src of the domElement
             domElement.srcObject = stream;
 


### PR DESCRIPTION
From testing, camera 0 is the default back camera on android (1x zoom lens) so the code tries to find this camera first. For iPhoen you can only select either front or back, no matter how many cameras so back is used by default.

<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
<!-- Can be a new feature, a bugfix, or refactoring, etc -->
Selects the regular lens on multi-camera smartphones instead of zoomed ones

**Can it be referenced to an Issue? If so what is the issue # ?**
#619 
#581 
#571 
#86  - Adapted some of the code from this issue

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->
A multi-camera smartphone is required. The basic.html can be used for testing. Just see which lens your phone uses.
I have only tested this on a couple of android phones.

**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->
This will use the correct 1x zoomed lens on android phones.

**Does this PR introduce a breaking change?**

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**

**Other information**
