### PR TITLE
set correct gps-camera selector for gps-entity-place

### DIFF
--- a/aframe/src/location-based/gps-entity-place.js
+++ b/aframe/src/location-based/gps-entity-place.js
@@ -21,7 +21,7 @@ AFRAME.registerComponent('gps-entity-place', {
         window.addEventListener('debug-ui-added', this.debugUIAddedHandler.bind(this));
 
         if (this._cameraGps === null) {
-            var camera = document.querySelector('a-camera, [camera]');
+            var camera = document.querySelector('[gps-camera]');
             if (camera.components['gps-camera'] === undefined) {
                 return;
             }


### PR DESCRIPTION


<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
The PR fixes the issue, that aframe creates a camera in the DOM and the component gps-entity-place finds this instead of the real gps-camera.

**Can it be referenced to an Issue? If so what is the issue # ?**
Issue: "GeoAR: camera.components['gps-camera'] is undefined #626"

**How can we test it?**
insert `<a-entity aframe-injected="" camera="" look-controls="" position="" rotation="" wasd-controls=""></a-entity>` into your `<a-scene>`, if it`s not created by aframe. Then add your `<a-camera gps-camera></a-camera>`.
`gps-entity-place` should allways select the gps-camera.

**Summary**
see above

**Does this PR introduce a breaking change?**
no

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**
Tested in a cordova app in android (Samsung Galaxy S9)

**Other information**
-