### PR TITLE
Added ability to return the AR Controller Instance

### DIFF
--- a/aframe/build/aframe-ar.js
+++ b/aframe/build/aframe-ar.js
@@ -102,6 +102,15 @@ var Qb=[Ik,Zh,_h,Qj,Qi,Pi,Ri,Ag,sg,qg,rg,yg,kh,jh,Oi,Mj];var Rb=[Jk,ki,ji,gi];va
 			this[t] = null;
 		}
 	};
+	
+
+	/**
+		Returns the AR Controller Instance - allowing prototype commands to be called from outside of the aframe-ar.js class
+	*/
+
+	getARController = function(){
+	return myController;
+	}
 
 	/**
 		Detects markers in the given image. The process method dispatches marker detection events during its run.


### PR DESCRIPTION
the AR Controller Instance allows prototype commands to be called from outside of the aframe-ar.js class

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**

New Feature

**Can it be referenced to an Issue? If so what is the issue # ?**
Getting Marker Locations - #636

**How can we test it?**

Used to get the quantity and position of the markers using:
var ARController = getARController();
var numMarkers = ARController.getMarkerNum();
var i;
for(i = 0 ; i< arController.getMarkerNum() ; i++){
console.log(arController.getMarker(i).pos);
}

**Summary**

Exposed Object so methods can be called from client - means we can get marker information out of Aframe and into our own program i.e the position thats being used to place the 3D overlay to changing the marker tracking type (colpour, mono) and more.

**Does this PR introduce a breaking change?**
Not that im aware of - perhaps saftey issyes?

Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser

Firefox 70.0.1 + laptop i5 7200U + windows 10 home

Other information