### PR TITLE
Fix for issue #670

### DIFF
--- a/three.js/src/threex/threex-artoolkitsource.js
+++ b/three.js/src/threex/threex-artoolkitsource.js
@@ -97,21 +97,15 @@ ARjs.Source.prototype.init = function(onReady, onError){
 
 ARjs.Source.prototype._initSourceImage = function(onReady) {
 	// TODO make it static
-        var domElement = document.createElement('img')
-	domElement.src = this.parameters.sourceUrl
+        var domElement = document.createElement('img');
+	domElement.src = this.parameters.sourceUrl;
 
-	domElement.width = this.parameters.sourceWidth
-	domElement.height = this.parameters.sourceHeight
-	domElement.style.width = this.parameters.displayWidth+'px'
-	domElement.style.height = this.parameters.displayHeight+'px'
+	domElement.width = this.parameters.sourceWidth;
+	domElement.height = this.parameters.sourceHeight;
+	domElement.style.width = this.parameters.displayWidth+'px';
+	domElement.style.height = this.parameters.displayHeight+'px';
 
-	// wait until the video stream is ready
-	var interval = setInterval(function() {
-		if (!domElement.naturalWidth)	return;
-		onReady()
-		clearInterval(interval)
-	}, 1000/50);
-
+	onReady();
 	return domElement
 }
 
@@ -123,33 +117,28 @@ ARjs.Source.prototype._initSourceImage = function(onReady) {
 ARjs.Source.prototype._initSourceVideo = function(onReady) {
 	// TODO make it static
 	var domElement = document.createElement('video');
-	domElement.src = this.parameters.sourceUrl
+	domElement.src = this.parameters.sourceUrl;
 
-	domElement.style.objectFit = 'initial'
+	domElement.style.objectFit = 'initial';
 
 	domElement.autoplay = true;
 	domElement.webkitPlaysinline = true;
 	domElement.controls = false;
 	domElement.loop = true;
-	domElement.muted = true
+	domElement.muted = true;
 
 	// trick to trigger the video on android
 	document.body.addEventListener('click', function onClick(){
 		document.body.removeEventListener('click', onClick);
 		domElement.play()
-	})
+	});
 
-	domElement.width = this.parameters.sourceWidth
-	domElement.height = this.parameters.sourceHeight
-	domElement.style.width = this.parameters.displayWidth+'px'
-	domElement.style.height = this.parameters.displayHeight+'px'
+	domElement.width = this.parameters.sourceWidth;
+	domElement.height = this.parameters.sourceHeight;
+	domElement.style.width = this.parameters.displayWidth+'px';
+	domElement.style.height = this.parameters.displayHeight+'px';
 
-	// wait until the video stream is ready
-	var interval = setInterval(function() {
-		if (!domElement.videoWidth)	return;
-		onReady()
-		clearInterval(interval)
-	}, 1000/50);
+	onReady();
 	return domElement
 }
 
@@ -185,7 +174,7 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
 		onError({
 			name: '',
 			message: 'WebRTC issue-! '+fctName+' not present in your browser'
-		})
+		});
 		return null
 	}
 
@@ -194,7 +183,7 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
                 var userMediaConstraints = {
 			audio: false,
 			video: {
-				facingMode: 'environment',
+				facingMode: {exact: 'environment'},
 				width: {
 					ideal: _this.parameters.sourceWidth,
 					// min: 1024,
@@ -206,7 +195,7 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
 					// max: 1080
 				}
 		  	}
-		}
+		};
 
 		if (null !== _this.parameters.deviceId) {
 			userMediaConstraints.video.deviceId = {
@@ -227,13 +216,7 @@ ARjs.Source.prototype._initSourceWebcam = function(onReady, onError) {
 			});
 			// domElement.play();
 
-// TODO listen to loadedmetadata instead
-			// wait until the video stream is ready
-			var interval = setInterval(function() {
-				if (!domElement.videoWidth)	return;
-				onReady()
-				clearInterval(interval)
-			}, 1000/50);
+			onReady();
 		}).catch(function(error) {
 			onError({
 				name: error.name,


### PR DESCRIPTION
It seems not to be necessary to wait for the stream, so it could be shown directly.
Also added some missing semicolons.

**What kind of change does this PR introduce?**
Fix for 3rd party integration (https://github.com/cordova-rtc/cordova-plugin-iosrtc) 

**Can it be referenced to an Issue? If so what is the issue # ?**
https://github.com/jeromeetienne/AR.js/issues/670

**How can we test it?**
Start AR.js in Browser or as a cordoja app in iOS aith activated cordova-plugin-iosrtc

**Summary**
The cordova-plugin-iosrtc is a native replacement of the webrtc function. In iOS its only allowed to use in native safari browser but not in 3rd party apps using WkWebView.
The Plugin does not provide the videoElement.videoWith, that is used to check if the video stream is ready, but in my tests it has not been necessary to wait for it.

**Does this PR introduce a breaking change?**
I hope not.

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**
Tested on Cordova in iOS13.2.2 (iPhone 7) and Android 9 (Galaxy S9 - Patch 11/19)
