### PR TITLE
Add uglifyjs as a dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .atom-live-server.json
+node_modules/*

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 watch: build
 	fswatch -0 three.js/src/*/*.js aframe/src/*.js babylon.js/src/*.js | xargs -0 -n 1 -I {} make build
 	
+prepare:
+	npm install
+
 build:
 	cd three.js && make build
 	cd aframe && make build
 
-minify:
+minify: prepare
 	cd three.js && make minify
 	cd aframe && make minify
 

--- a/aframe/Makefile
+++ b/aframe/Makefile
@@ -1,3 +1,4 @@
+UGLIFY=../node_modules/.bin/uglifyjs
 watch: build
 	fswatch -0 src/*.js ../three.js/src/*/*.js | xargs -0 -n 1 -I {} make build
 	
@@ -11,4 +12,4 @@ build:
 		> build/aframe-ar.js 
 
 minify: build
-	uglifyjs build/aframe-ar.js > build/aframe-ar.min.js
+	$(UGLIFY) build/aframe-ar.js > build/aframe-ar.min.js

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "bugs": {
     "url": "https://github.com/jeromeetienne/AR.js/issues"
   },
-  "homepage": "https://github.com/jeromeetienne/AR.js#readme"
+  "homepage": "https://github.com/jeromeetienne/AR.js#readme",
+  "devDependencies": {
+    "uglify-js": "^3.7.5"
+  }
 }

--- a/three.js/Makefile
+++ b/three.js/Makefile
@@ -1,3 +1,4 @@
+UGLIFY=../node_modules/.bin/uglifyjs
 watch: build
 	fswatch -0 src/*/*.js | xargs -0 -n 1 -I {} make build
 
@@ -12,7 +13,7 @@ build-main:
 .PHONY: build
 
 minify-main: build-main
-	uglifyjs build/ar.js > build/ar.min.js
+	$(UGLIFY) build/ar.js > build/ar.min.js
 
 build-lean:
 	echo > build/ar.lean.js
@@ -23,7 +24,7 @@ build-lean:
 		src/markers-area/*.js >> build/ar.lean.js
 
 minify-lean: build-lean
-	uglifyjs build/ar.lean.js > build/ar.lean.min.js
+	$(UGLIFY) build/ar.lean.js > build/ar.lean.min.js
 
 build: build-main build-lean
 


### PR DESCRIPTION
<!-- Please, don't delete this template or we'll close your issue -->

**⚠️ All PRs have to be done versus 'dev' branch, so be aware of that, or we'll close your issue ⚠️**

**What kind of change does this PR introduce?**
Fix the local build when somebody use `make build && make minify` (which crash on `make minify`).

**Can it be referenced to an Issue? If so what is the issue # ?**
Issue #703 

**How can we test it?**
<!-- All information can be found about our tests in https://github.com/jeromeetienne/AR.js/blob/master/test/TODO.md -->
<!-- At the moment we don't explicitly require tests, because it's not streamlined yet -->
Checkout the branch in a fresh environment (without a global .node_modules loaded), and do a `make build && make minify`. This command should not fail and the minified files should be present.

**Summary**
<!-- State here what problem the PR solves and what is the proposed solution -->
1. Add the tool `uglifyjs` to `package.json` dev dependencies.
2. Add a `prepare` goal in the main `Makefile` which will execute a `npm install` and make this goal a dependency of the `minify` one.

**Does this PR introduce a breaking change?**
No.

**Please TEST your PR before proposing it. Specify here what device you have used for tests, version of OS and version of Browser**
Not applicable.

**Other information**
This change should be tested over the Travis pipeline to ensure non-regression.